### PR TITLE
refactor: improve travel endpoint and cost calculation

### DIFF
--- a/backend/src/travel/travel.controller.ts
+++ b/backend/src/travel/travel.controller.ts
@@ -46,11 +46,11 @@ export class TravelController {
         description: 'Unauthorized - User not authenticated'
     })
     async startRentingBike(
-        @Param('bikeId') bikeId: string,
+        @Param('id') id: string,
         @Req() req: any
     ) {
         const userId = req.user.githubId;
-        return this.travelService.startRentingBike(bikeId, userId);
+        return this.travelService.startRentingBike(id, userId);
     }
 
     // End a bike travel

--- a/backend/src/travel/travel.controller.ts
+++ b/backend/src/travel/travel.controller.ts
@@ -54,9 +54,11 @@ export class TravelController {
     }
 
     // End a bike travel
-    @Post('end')
-    @UseGuards(JwtAuthGuard)
-    @ApiBearerAuth()
+    @Post(':id/end')
+    // removing the guard for now, the bike software should be able to end a travel. 
+    // we could implement a guard that authenticates the bike somehow
+    // we could also expand on this, making it even more complex, like checking that it is the user whom initlized the rental that is ending it
+    // @UseGuards(JwtAuthGuard)
     @ApiOperation({
         summary: 'End a bike travel',
         description: 'Ends the travel, calculates cost, and makes the bike available again'
@@ -73,7 +75,7 @@ export class TravelController {
         status: 401,
         description: 'Unauthorized'
     })
-    async endTravel(@Body() endTravelDto: EndTravelDto) {
-        return this.travelService.endTravel(endTravelDto.travelId);
+    async endTravel(@Param('id') travelId: number) {
+        return this.travelService.endTravel(travelId);
     }
 }

--- a/backend/src/travel/travel.service.ts
+++ b/backend/src/travel/travel.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Travel } from './entities/travel.entity';
 import { BicyclesService } from '../bicycles/bicycles.service';
+import { time } from 'console';
 
 @Injectable()
 export class TravelService {
@@ -101,7 +102,8 @@ export class TravelService {
 
   getZoneType(lat: number, long: number): 'Free' | 'Parking' {
     // Dummy implementation for now
-    return 'Free';
+    // randomize the zone type
+    return Math.random() > 0.5 ? 'Free' : 'Parking'; 
   }
 
   
@@ -111,7 +113,15 @@ export class TravelService {
     startZoneType: string,
     endZoneType: string,
   ): number {
-    // Dummy implementation for now
-    return 50; // Example fixed cost
+    const timeDiff = endTime.getTime() - startTime.getTime();
+    const timeDiffInMinutes = timeDiff / 1000 / 60;
+
+    const parkingFee = 10;
+    const startFee = 10;
+    const costPerMinute = 1;
+    
+    let cost = (endZoneType === 'Parking' ? 0 : parkingFee) + (startZoneType === 'Free' && endZoneType === 'Parking' ? startFee/2 : startFee) + timeDiffInMinutes*costPerMinute;
+
+    return cost;
   }
 }


### PR DESCRIPTION
- Make travel endpoint more REST-idiomatic by moving travel ID to URL param
- Remove JWT auth guard to support bike-initiated rental ends
- Add comments about future authentication requirements
- Implement cost calculation based on time and zone types
- Add randomization to zone type for testing

The endpoint change moves from POST /travel/end to POST /travel/:id/end, following REST conventions. Authentication is disabled to allow both user and bike-initiated rental ends.

Cost calculation now considers:
- Base start fee (with discount for Free->Parking)
- Time-based charges
- Parking zone penalties