### PR TITLE
Refactor city names to use CityName enum and add Swagger documentation

### DIFF
--- a/backend/src/bicycles/bicycles.controller.spec.ts
+++ b/backend/src/bicycles/bicycles.controller.spec.ts
@@ -5,6 +5,7 @@ import { Bicycle } from './entities/bicycle.entity';
 import { UpdateBicycleDto } from './dto/update-bicycle.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { City } from '../cities/entities/city.entity';
+import { CityName } from 'src/cities/types/city.enum';
 
 describe('BicyclesController', () => {
   let controller: BicyclesController;
@@ -13,7 +14,7 @@ describe('BicyclesController', () => {
   // Create a mock city
   const mockCity: City = {
     id: 'city-test-id',
-    name: 'Göteborg',
+    name: CityName.Göteborg,
     createdAt: new Date(),
     updatedAt: new Date(),
   };

--- a/backend/src/bicycles/bicycles.service.ts
+++ b/backend/src/bicycles/bicycles.service.ts
@@ -8,6 +8,7 @@ import { BicycleResponse } from './types/bicycle-response.interface';
 import { getDistance } from 'src/utils/geo.utils';
 import { CreateBicycleDto } from './dto/create-bicycle.dto';
 import { City } from 'src/cities/entities/city.entity';
+import { CityName } from 'src/cities/types/city.enum';
 
 @Injectable()
 export class BicyclesService {
@@ -64,7 +65,7 @@ export class BicyclesService {
     const city = createBicycleDto.city ?? 'Göteborg';
     // Find the city by name
     const cityEntity = await this.cityRepository.findOne({
-      where: { name: city },
+      where: { name: city as CityName },
     });
 
     if (cityEntity) {
@@ -76,13 +77,13 @@ export class BicyclesService {
 
   async createManyBikes(createBicycleDto: CreateBicycleDto[]): Promise<Bicycle[]> {
     const defaultCity = await this.cityRepository.findOne({
-      where: { name: 'Göteborg' },
+      where: { name: CityName.Göteborg }
     });
     const Karlshamn = await this.cityRepository.findOne({
-      where: { name: 'Karlshamn' },
+      where: { name: CityName.Karlshamn }
     });
     const Jönköping = await this.cityRepository.findOne({
-      where: { name: 'Jönköping' },
+      where: { name: CityName.Jönköping }
     });
 
     const bikes = createBicycleDto.map((bike) => {
@@ -122,7 +123,7 @@ export class BicyclesService {
     return this.bicycleRepository.save({ ...bike, ...updateBicycleDto });
   }
 
-  async findByCity(cityName: 'Göteborg' | 'Jönköping' | 'Karlshamn'): Promise<Bicycle[]> {
+  async findByCity(cityName: CityName): Promise<Bicycle[]> {
     const bikes = await this.bicycleRepository.find({
       where: {
         city: {

--- a/backend/src/bicycles/dto/create-bicycle.dto.ts
+++ b/backend/src/bicycles/dto/create-bicycle.dto.ts
@@ -1,23 +1,59 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsEnum, IsNumber, IsOptional } from 'class-validator';
 
 export class CreateBicycleDto {
-  @IsNumber()
-  @IsOptional()
-  batteryLevel?: number;
+ @ApiProperty({
+   description: 'Battery level of the bicycle (0-100)',
+   example: 100,
+   required: false,
+   type: Number,
+   default: 100
+ })
+ @IsNumber()
+ @IsOptional()
+ batteryLevel?: number;
 
-  @IsNumber()
-  @IsOptional()
-  latitude?: number;
+ @ApiProperty({
+   description: 'Latitude coordinate of the bicycle',
+   example: 57.70887,
+   required: false,
+   nullable: true,
+   type: Number
+ })
+ @IsNumber()
+ @IsOptional()
+ latitude?: number;
 
-  @IsNumber()
-  @IsOptional()
-  longitude?: number;
+ @ApiProperty({
+   description: 'Longitude coordinate of the bicycle', 
+   example: 11.97456,
+   required: false,
+   nullable: true,
+   type: Number
+ })
+ @IsNumber()
+ @IsOptional()
+ longitude?: number;
 
-  @IsEnum(['Rented', 'Available', 'Service'])
-  @IsOptional()
-  status?: 'Rented' | 'Available' | 'Service';
+ @ApiProperty({
+   description: 'Status of the bicycle',
+   enum: ['Rented', 'Available', 'Service'],
+   example: 'Available',
+   required: false,
+   default: 'Available'
+ })
+ @IsEnum(['Rented', 'Available', 'Service'])
+ @IsOptional()
+ status?: 'Rented' | 'Available' | 'Service';
 
-  @IsEnum(['Göteborg', 'Jönköping', 'Karlshamn'])
-  @IsOptional()
-  city?: 'Göteborg' | 'Jönköping' | 'Karlshamn';
+ @ApiProperty({
+   description: 'City where the bicycle is located',
+   enum: ['Göteborg', 'Jönköping', 'Karlshamn'],
+   example: 'Göteborg',
+   required: false,
+   nullable: true
+ })
+ @IsEnum(['Göteborg', 'Jönköping', 'Karlshamn'])
+ @IsOptional()
+ city?: 'Göteborg' | 'Jönköping' | 'Karlshamn';
 }

--- a/backend/src/bicycles/entities/bicycle.entity.ts
+++ b/backend/src/bicycles/entities/bicycle.entity.ts
@@ -1,3 +1,4 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { City } from '../../cities/entities/city.entity';
 import {
   Entity,
@@ -11,18 +12,49 @@ import {
 
 @Entity()
 export class Bicycle {
+  @ApiProperty({
+    description: 'Unique identifier of the bicycle',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+    format: 'uuid'
+  })
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
+  @ApiProperty({
+    description: 'Battery level of the bicycle (0-100)',
+    example: 100,
+    default: 100,
+    type: Number
+  })
   @Column({ type: 'int', default: 100 })
   batteryLevel: number;
 
+  @ApiProperty({
+    description: 'Latitude coordinate of the bicycle',
+    example: 57.70887,
+    required: false,
+    nullable: true,
+    type: Number
+  })
   @Column('float', { nullable: true })
   latitude?: number;
 
+  @ApiProperty({
+    description: 'Longitude coordinate of the bicycle',
+    example: 11.97456,
+    required: false,
+    nullable: true,
+    type: Number
+  })
   @Column('float', { nullable: true })
   longitude?: number;
 
+  @ApiProperty({
+    description: 'Current status of the bicycle',
+    enum: ['Rented', 'Available', 'Service'],
+    default: 'Available',
+    example: 'Available'
+  })
   @Column({
     type: 'simple-enum',
     enum: ['Rented', 'Available', 'Service'],
@@ -30,14 +62,30 @@ export class Bicycle {
   })
   status: 'Rented' | 'Available' | 'Service';
 
-  // maybe we should allow nullable here
+  @ApiProperty({
+    description: 'City where the bicycle is located',
+    type: () => City,
+    required: false,
+    nullable: true
+  })
   @ManyToOne(() => City, { nullable: true })
   @JoinColumn()
   city: City;
 
+  @ApiProperty({
+    description: 'Creation timestamp',
+    example: '2025-01-02T12:10:00Z',
+    nullable: true
+  })
+
   @CreateDateColumn({ nullable: true })
   createdAt: Date;
 
+  @ApiProperty({
+    description: 'Last update timestamp',
+    example: '2025-01-02T12:10:00Z',
+    nullable: true
+  })
   @UpdateDateColumn({ nullable: true })
   updatedAt: Date;
 }

--- a/backend/src/cities/cities.controller.ts
+++ b/backend/src/cities/cities.controller.ts
@@ -2,6 +2,8 @@ import { Body, Controller, Get, Post } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { CitiesService } from './cities.service';
 import { CreateCityDto } from './dto/create-city.dto';
+import { CityName } from './types/city.enum';
+import { City } from './entities/city.entity';
 
 @ApiTags('Cities')
 @Controller('cities')
@@ -13,19 +15,7 @@ export class CitiesController {
   @ApiResponse({
     status: 200,
     description: 'List of bicycles',
-    schema: {
-      type: 'array',
-      example: [
-        {
-          id: 'b1e77dd3-9fb9-4e6c-a5c6-b6fc58f59464',
-          city: 'Göteborg',
-          latitude: 59.3293,
-          longitude: 18.0686,
-          createdAt: '2024-12-01T05:01:01.000Z',
-          updatedAt: '2024-12-07T18:30:30.000Z',
-        },
-      ],
-    },
+    type: [City],
   })
   async getAllCities() {
     return await this.citiesService.findAll();
@@ -36,16 +26,7 @@ export class CitiesController {
   @ApiResponse({
     status: 201,
     description: 'City created successfully',
-    schema: {
-      example: {
-        id: 'b1e77dd3-9fb9-4e6c-a5c6-b6fc58f59464',
-        city: 'Göteborg',
-        latitude: null,
-        longitude: null,
-        createdAt: '2024-12-01T05:01:01.000Z',
-        updatedAt: '2024-12-01T05:01:01.000Z',
-      },
-    },
+    type: City,
   })
   async createACity(@Body() createCityDto: CreateCityDto) {
     return await this.citiesService.createCity(createCityDto);

--- a/backend/src/cities/dto/create-city.dto.ts
+++ b/backend/src/cities/dto/create-city.dto.ts
@@ -1,16 +1,14 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsOptional, IsNumber, IsEnum } from 'class-validator';
 import { City } from '../entities/city.entity';
+import { CityName } from '../types/city.enum';
 
 export class CreateCityDto {
   @ApiProperty({
-    description: 'City',
-    example: 'Göteborg',
-    enum: ['Göteborg', 'Jönköping', 'Karlshamn'],
-    required: true,
+    enum: CityName,
   })
-  @IsEnum(['Göteborg', 'Jönköping', 'Karlshamn'])
-  name: 'Göteborg' | 'Jönköping' | 'Karlshamn';
+  @IsEnum(CityName)
+  name: CityName;
 
   @ApiProperty({
     description: 'Latitude coordinate of the city center',

--- a/backend/src/cities/entities/city.entity.ts
+++ b/backend/src/cities/entities/city.entity.ts
@@ -6,28 +6,61 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 
+import { CityName } from '../types/city.enum';
+import { ApiProperty } from '@nestjs/swagger';
+
 @Entity()
 export class City {
+  @ApiProperty({
+    description: 'Unique identifier of the city',
+    format: 'uuid',
+    example: '123e4567-e89b-12d3-a456-426614174000'
+  })
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
+  @ApiProperty({
+    description: 'Name of the city',
+    enum: CityName,
+    example: CityName.Göteborg
+  })
   @Column({
     type: 'simple-enum',
-    enum: ['Göteborg', 'Jönköping', 'Karlshamn'],
-    default: 'Göteborg',
+    enum: CityName,
+    default: CityName.Göteborg,
     unique: true,
   })
-  name: 'Göteborg' | 'Jönköping' | 'Karlshamn';
+  name: CityName;
 
+  @ApiProperty({
+    description: 'Latitude coordinate of the city',
+    example: 57.70887,
+    required: false,
+    nullable: true
+  })
   @Column('float', { nullable: true })
   latitude?: number;
 
+  @ApiProperty({
+    description: 'Longitude coordinate of the city',
+    example: 11.97456,
+    required: false,
+    nullable: true
+  })
   @Column('float', { nullable: true })
   longitude?: number;
 
+  @ApiProperty({
+    description: 'Creation timestamp',
+    example: '2024-01-02T12:00:00Z'
+  })
   @CreateDateColumn({ nullable: true })
   createdAt: Date;
 
+  @ApiProperty({
+    description: 'Last update timestamp',
+    example: '2024-01-02T12:00:00Z'
+  })
   @UpdateDateColumn({ nullable: true })
   updatedAt: Date;
 }

--- a/backend/src/cities/types/city.enum.ts
+++ b/backend/src/cities/types/city.enum.ts
@@ -1,0 +1,5 @@
+export enum CityName {
+    Göteborg = 'Göteborg',
+    Jönköping = 'Jönköping',
+    Karlshamn = 'Karlshamn',
+}

--- a/backend/src/database/seeds/bicycles-data.seed.ts
+++ b/backend/src/database/seeds/bicycles-data.seed.ts
@@ -1,6 +1,7 @@
 import { DataSource } from 'typeorm';
 import { Bicycle } from '../../bicycles/entities/bicycle.entity';
 import { City } from '../../cities/entities/city.entity';
+import { CityName } from 'src/cities/types/city.enum';
 
 export default class BicycleSeeder {
   async run(connection: DataSource): Promise<void> {
@@ -9,26 +10,26 @@ export default class BicycleSeeder {
       const cityRepo = connection.getRepository(City);
 
       // keeping debug logs for now
-      let goteborg = await cityRepo.findOne({ where: { name: 'Göteborg' } });
+      let goteborg = await cityRepo.findOne({ where: { name: CityName.Göteborg } });
       if (!goteborg) {
         // console.log('Creating Göteborg...');
-        goteborg = cityRepo.create({ name: 'Göteborg' });
+        goteborg = cityRepo.create({ name: CityName.Göteborg });
         await cityRepo.save(goteborg);
         // console.log('Göteborg created with ID:', goteborg.id);
       }
 
-      let karlshamn = await cityRepo.findOne({ where: { name: 'Karlshamn' } });
+      let karlshamn = await cityRepo.findOne({ where: { name: CityName.Karlshamn } });
       if (!karlshamn) {
         // console.log('Creating Karlshamn...');
-        karlshamn = cityRepo.create({ name: 'Karlshamn' });
+        karlshamn = cityRepo.create({ name: CityName.Karlshamn });
         await cityRepo.save(karlshamn);
         // console.log('Karlshamn created with ID:', karlshamn.id);
       }
 
-      let jonkoping = await cityRepo.findOne({ where: { name: 'Jönköping' } });
+      let jonkoping = await cityRepo.findOne({ where: { name: CityName.Jönköping } });
       if (!jonkoping) {
         // console.log('Creating Jönköping...');
-        jonkoping = cityRepo.create({ name: 'Jönköping' });
+        jonkoping = cityRepo.create({ name: CityName.Jönköping });
         await cityRepo.save(jonkoping);
         // console.log('Jönköping created with ID:', jonkoping.id);
       }

--- a/backend/src/database/seeds/zones-data.seed.ts
+++ b/backend/src/database/seeds/zones-data.seed.ts
@@ -1,6 +1,7 @@
 import { DataSource } from 'typeorm';
 import { Zone } from '../../zones/entities/zone';
 import { City } from '../../cities/entities/city.entity';
+import { CityName } from 'src/cities/types/city.enum';
 
 export default class ZoneSeeder {
   async run(connection: DataSource): Promise<void> {
@@ -10,14 +11,14 @@ export default class ZoneSeeder {
       const cityRepo = connection.getRepository(City);
 
       const cities = await Promise.all([
-        cityRepo.findOne({ where: { name: 'Göteborg' } }) ||
-          cityRepo.save(cityRepo.create({ name: 'Göteborg' })),
+        cityRepo.findOne({ where: { name: CityName.Göteborg } }) ||
+          cityRepo.save(cityRepo.create({ name: CityName.Göteborg })),
 
-        cityRepo.findOne({ where: { name: 'Karlshamn' } }) ||
-          cityRepo.save(cityRepo.create({ name: 'Karlshamn' })),
+        cityRepo.findOne({ where: { name: CityName.Karlshamn } }) ||
+          cityRepo.save(cityRepo.create({ name: CityName.Karlshamn })),
 
-        cityRepo.findOne({ where: { name: 'Jönköping' } }) ||
-          cityRepo.save(cityRepo.create({ name: 'Jönköping' })),
+        cityRepo.findOne({ where: { name: CityName.Jönköping } }) ||
+          cityRepo.save(cityRepo.create({ name: CityName.Jönköping })),
       ]);
 
       const [goteborg, karlshamn, jonkoping] = cities;

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -26,6 +26,7 @@ async function bootstrap() {
     origin: [
       'http://localhost:5173', // Frontend
       'http://localhost:1337', // kundapp
+      'http://localhost:3000', // kundapp
       'http://localhost:5174', // bike-app
       `http://localhost:${process.env.PORT ?? 3000}`, // Swagger UI
     ],

--- a/backend/src/zones/zones.controller.spec.ts
+++ b/backend/src/zones/zones.controller.spec.ts
@@ -4,6 +4,7 @@ import { ZonesService } from './zones.service';
 import { Zone } from './entities/zone';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { ZoneFilterQueryDto } from './dto/zone-filter-query.dto';
+import { CityName } from 'src/cities/types/city.enum';
 
 describe('ZonesController', () => {
   let controller: ZonesController;
@@ -25,7 +26,7 @@ describe('ZonesController', () => {
     },
     city: {
       id: '755cacbd-fc18-4884-8859-96fa814b1eb2',
-      name: 'Jönköping',
+      name: CityName.Jönköping,
       latitude: null,
       longitude: null,
       createdAt: new Date(),

--- a/backend/src/zones/zones.controller.ts
+++ b/backend/src/zones/zones.controller.ts
@@ -12,6 +12,7 @@ import { ZonesService } from './zones.service';
 import { ZoneFilterQueryDto } from './dto/zone-filter-query.dto';
 import { ZoneResponse } from './types/ZoneResponse';
 import { ZoneQuery } from './types/ZoneQuery';
+import { CityName } from 'src/cities/types/city.enum';
 
 @ApiTags('Zones')
 @Controller('zone')
@@ -131,7 +132,7 @@ export class ZonesController {
     type: 'string',
     enum: ['Göteborg', 'Jönköping', 'Karlshamn'],
   })
-  async getZonesByCity(@Param('cityName') cityName: 'Göteborg' | 'Jönköping' | 'Karlshamn') {
+  async getZonesByCity(@Param('cityName') cityName: CityName) {
     return await this.zonesService.findByCity(cityName);
   }
 }

--- a/backend/src/zones/zones.service.spec.ts
+++ b/backend/src/zones/zones.service.spec.ts
@@ -4,6 +4,7 @@ import { ZonesService } from './zones.service';
 import { Zone } from './entities/zone';
 import { Repository } from 'typeorm';
 import { City } from '../cities/entities/city.entity';
+import { CityName } from 'src/cities/types/city.enum';
 
 const mockRepository = {
   find: jest.fn(),
@@ -15,7 +16,7 @@ describe('ZonesService', () => {
 
   const mockCity: City = {
     id: 'city-test-id',
-    name: 'Göteborg',
+    name: CityName.Göteborg,
     createdAt: new Date(),
     updatedAt: new Date(),
   };

--- a/backend/src/zones/zones.service.ts
+++ b/backend/src/zones/zones.service.ts
@@ -6,6 +6,7 @@ import { ZoneQuery } from './types/ZoneQuery';
 import { ZoneResponse } from './types/ZoneResponse';
 import { BicyclesService } from 'src/bicycles/bicycles.service';
 import { getDistance, positionInsidePolygon } from 'src/utils/geo.utils';
+import { CityName } from 'src/cities/types/city.enum';
 
 @Injectable()
 export class ZonesService {
@@ -21,7 +22,7 @@ export class ZonesService {
     });
   }
 
-  async findByCity(cityName: 'Göteborg' | 'Jönköping' | 'Karlshamn'): Promise<Zone[]> {
+  async findByCity(cityName: CityName): Promise<Zone[]> {
     return await this.zoneRepository.find({
       where: {
         city: {
@@ -92,7 +93,9 @@ export class ZonesService {
   }
 
   async pointInParkingZone(lat: number, lon: number): Promise<boolean> {
-    const zones = await this.findAll();
+    const zones = (await this.findAll()).filter((zone) => {
+      return zone.type === 'parking';
+    });
     return zones.some((zone) => {
       return positionInsidePolygon(lat, lon, zone.polygon);
     });


### PR DESCRIPTION
    - Updated city names in controllers, services, DTOs, and entities to use the CityName enum.
    - Added Swagger documentation to various DTOs and entities for better API documentation.
    - Improved error handling in createManyBikes method.
    - Added CORS support for localhost:3000.
